### PR TITLE
Add ascii art diagram to ch06_6.14_1.hs

### DIFF
--- a/ch06/ch06_6.14_1.hs
+++ b/ch06/ch06_6.14_1.hs
@@ -1,2 +1,20 @@
 arith :: Num b => (a -> b) -> Integer -> a -> b
 arith f i a = (f a) + (fromInteger i)
+{-
+ - (+)    :: Num a =>   a      ->    a     ->     a
+ - (-)    :: Num a =>   a      ->    a     ->     a
+ - (*)    :: Num a =>   a      ->    a     ->     a
+ -                      ^       ^    ^      ^     ^
+ -                       \      |     \      \    |
+ -                        \     |      +---+  \   |
+ -                         \    |           \  \  |
+ -                          v   v            v  v v
+ - arith  :: Num b => (a -> b) -> Integer -> a -> b
+ -                     ^  ^          ^     ^
+ -                     |  |          |     |
+ -                     +  +          |     |
+ -                      \/           +-----------+
+ -                      /\                 |     |
+ -                     v  v                v     v
+ - arith f i a =      (f  a)    +   (fromInteger i)
+ -}


### PR DESCRIPTION
I had to cheat on this exercise when self studying from the book. After looking at this file, it took me a long time to understand the reasoning of how you'd got to the answer you did. So, I made this ASCII art diagram to explain how the type signature for `arith` fits it's term-level implementation. Hopefully this will help others get a sense of how to break these problems down. Or not, it's just a silly thing, anyways.